### PR TITLE
Fixes errors and improves in smda-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ include = ["assets", "src"]
 edition = "2021"
 
 [dependencies]
-capstone = "0.10.0"
+capstone = "0.11.0"
 data-encoding = "2.3.2"
-goblin = { version = "0.7.1", features = ["alloc"] }
+goblin = { version = "0.8.0", features = ["alloc"] }
 hex = "0.4.3"
-itertools = "0.10.3"
+itertools = "0.12.0"
 lazy_static = "1"
 maplit = "1.0.2"
 regex = "1.5.5"

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,8 @@ pub enum Error {
     ParseError(#[from] goblin::error::Error),
     #[error("{0}")]
     IoError(#[from] std::io::Error),
+    #[error("PE file has sections that map outside of the intended space")]
+    PEOutOfBoundsSectionError,
 
     #[error("unsupported format")]
     UnsupportedFormatError,

--- a/src/function.rs
+++ b/src/function.rs
@@ -112,17 +112,18 @@ impl Instruction {
                         let value = match op.op_type {
                             capstone::arch::x86::X86OperandType::Imm(op_value) => op_value,
                             capstone::arch::x86::X86OperandType::Mem(op_value) => {
-                                if let Some(s) = capstone.reg_name(op_value.base()) {
-                                    if s == "rip" {
-                                        //add RIP value
-                                        op_value.disp()
-                                            + insn.address() as i64
-                                            + insn.bytes().len() as i64
-                                    } else {
-                                        op_value.disp()
+                                match capstone.reg_name(op_value.base()) {
+                                    Some(s) => {
+                                        if s == "rip" {
+                                            //add RIP value
+                                            op_value.disp()
+                                                + insn.address() as i64
+                                                + insn.bytes().len() as i64
+                                        } else {
+                                            op_value.disp()
+                                        }
                                     }
-                                } else {
-                                    op_value.disp()
+                                    _ => op_value.disp(),
                                 }
                             }
                             _ => 0,

--- a/src/function_candidate_manager.rs
+++ b/src/function_candidate_manager.rs
@@ -514,7 +514,7 @@ impl FunctionCandidateManager {
         Ok(true)
     }
 
-    fn add_reference_candidate(
+    pub fn add_reference_candidate(
         &mut self,
         addr: u64,
         source_ref: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1350,7 +1350,8 @@ impl Disassembler {
                 self.fc_manager
                     .add_candidate(a.0, false, Some(a.1), &self.disassembly)?;
             }
-            self.tailcall_analyzer.finalize_function(&state)?;
+            // self.tailcall_analyzer.finalize_function(&state)?;
+            TailCallAnalyser::finalize_function(self, &mut state)?;
         }
         self.fc_manager.update_analysis_finished(&start_addr)?;
         if high_accuracy {

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -75,6 +75,9 @@ pub fn map_binary(binary: &[u8]) -> Result<Vec<u8>> {
             optional_header_size = 0x108;
         }
     }
+    if binary.len() < pe_offset + optional_header_size + num_sections * 0x28 {
+        return Err(Error::PEOutOfBoundsSectionError);
+    }
     if binary.len() >= pe_offset + optional_header_size + num_sections * 0x28 {
         for section_index in 0..num_sections {
             let section_offset = section_index * 0x28;

--- a/src/tail_call_analyser.rs
+++ b/src/tail_call_analyser.rs
@@ -38,11 +38,21 @@ impl TailCallAnalyser {
         Ok(())
     }
 
-    pub fn finalize_function(&mut self, _function_state: &FunctionAnalysisState) -> Result<()> {
-        for (source, destinations) in &self.tmp_jumps {
-            self.jumps.insert(*source, destinations.to_vec());
+    pub fn finalize_function(disassembler: &mut Disassembler, _function_state: &FunctionAnalysisState) -> Result<()> {
+        for (source, destinations) in &disassembler.tailcall_analyzer.tmp_jumps {
+            disassembler.tailcall_analyzer.jumps.insert(*source, destinations.to_vec());
+
+            for d in destinations {
+                _ = disassembler.fc_manager.add_reference_candidate(
+                    *d as u64,
+                    *source as u64,
+                    &disassembler.disassembly,
+                );
+                //let state = FunctionAnalysisState::new(*d)?;
+                //disassembler.tailcall_analyzer.functions.insert(*source, state);
+            }
         }
-        self.tmp_jumps.clear();
+        disassembler.tailcall_analyzer.tmp_jumps.clear();
         //TODO        self.functions.push(function_state);
         Ok(())
     }


### PR DESCRIPTION
Fixes errors in smda-rs
- Enhance jump processing in finalize_function
- Validate PE section bounds to prevent out-of-bounds errors
- Refine address validation in disassembly processing
- Implement signed address calculation for call destinations
- Optimize address handling and integrate code area filtering
- Refactor RIP-relative address calculation using match
- Upgrade libs capstone, goblin and itertools