### PR TITLE
Refine byte feature extraction based on FileArchitecture and Instruction visibility

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -7,7 +7,7 @@ pub struct Instruction {
     arch: FileArchitecture,
     bitness: u32,
     pub offset: u64,
-    bytes: String,
+    pub bytes: String,
     pub mnemonic: String,
     pub operands: Option<String>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ impl std::fmt::Display for FileFormat {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum FileArchitecture {
     I386,
     AMD64,


### PR DESCRIPTION
- Implement PartialEq and Eq for FileArchitecture to enable architecture-based logic in feature extraction.
- Expose the bytes field in Instruction to calculate the context-based byte length for feature extraction, improving accuracy for AMD64 architecture.