### PR TITLE
fix: Change HashMap to BTreeMap for deterministic function ordering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "smda"
 description = "SMDA is a minimalist recursive disassembler library."
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Marirs <marirs@gmail.com>", "Andrey Mnatsakanov <andrey@3ig.kiev.ua>"]
 keywords = ["smda", "disassembler", "cfg", "capstone"]
 categories = ["parsing", "development-tools::debugging"]
@@ -13,14 +13,14 @@ include = ["assets", "src"]
 edition = "2021"
 
 [dependencies]
-capstone = "0.12.0"
+capstone = "0.13.0"
 data-encoding = "2.6.0"
-goblin = { version = "0.9.1", features = ["alloc"] }
+goblin = { version = "0.9.3", features = ["alloc"] }
 hex = "0.4.3"
 itertools = "0.13.0"
 lazy_static = "1"
 maplit = "1.0.2"
-regex = "1"
+regex = "1.5.5"
 ring = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/function_candidate_manager.rs
+++ b/src/function_candidate_manager.rs
@@ -5,7 +5,7 @@ use crate::{
 use capstone::prelude::*;
 use itertools::Itertools;
 use regex::bytes::Regex as BytesRegex;
-use std::{collections::HashMap, convert::TryInto};
+use std::{collections::HashMap, collections::BTreeMap, convert::TryInto};
 
 lazy_static! {
     static ref DEFAULT_PROLOGUES: Vec<BytesRegex> = vec![
@@ -164,7 +164,7 @@ pub struct FunctionCandidateManager {
     code_areas: Vec<(u64, u64)>,
     all_call_refs: HashMap<u64, u64>,
     pub symbol_addresses: Vec<u64>,
-    pub candidates: HashMap<u64, FunctionCandidate>,
+    pub candidates: BTreeMap<u64, FunctionCandidate>,
     candidate_offsets: Vec<u64>,
     gs: GapSequences,
     candidate_queue: Vec<u64>,
@@ -182,7 +182,7 @@ impl FunctionCandidateManager {
             code_areas: vec![],
             all_call_refs: HashMap::new(),
             symbol_addresses: vec![],
-            candidates: HashMap::<u64, FunctionCandidate>::new(),
+            candidates: BTreeMap::<u64, FunctionCandidate>::new(),
             candidate_offsets: vec![],
             gs: GapSequences::new(),
             candidate_queue: vec![],
@@ -507,7 +507,7 @@ impl FunctionCandidateManager {
     }
 
     fn ensure_candidate(&mut self, addr: u64, disassembly: &DisassemblyResult) -> Result<bool> {
-        if let std::collections::hash_map::Entry::Vacant(e) = self.candidates.entry(addr) {
+        if let std::collections::btree_map::Entry::Vacant(e) = self.candidates.entry(addr) {
             e.insert(FunctionCandidate::new(&disassembly.binary_info, addr)?);
             return Ok(true);
         }

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -52,9 +52,9 @@ pub fn get_code_areas(binary: &[u8], pe: &goblin::pe::PE) -> Result<Vec<(u64, u6
             let mut section_size = section.virtual_size as u64;
             if section_size % 0x1000 != 0 {
                 section_size += 0x1000 - (section_size % 0x1000);
-                let section_end = section_start + section_size;
-                res.push((section_start, section_end));
             }
+            let section_end = section_start + section_size;
+            res.push((section_start, section_end));
         }
     }
     Ok(res)


### PR DESCRIPTION
- This commit changes the data structure used for storing function candidates from HashMap to BTreeMap. Since BTreeMap maintains keys in sorted order, this ensures consistent function ordering across runs, fixing the issue where different numbers of functions were being returned on each execution.
- Results were unstable in 1e2791877da02d49998dea79515a89ca due to the non-deterministic 
nature of HashMap iteration ordering.
- Also fixes a critical bug in get_code_areas() where executable sections that were already aligned to 0x1000 bytes were being excluded from the results.